### PR TITLE
Add an option to keep the cache

### DIFF
--- a/pkgproxy.go
+++ b/pkgproxy.go
@@ -264,6 +264,7 @@ func main() {
 	flAddr := flag.String("port", ":8080", "Listen on addr")
 	flUpstream := flag.String("upstream", "https://mirrors.kernel.org/archlinux/$repo/os/$arch", "Upstream URL")
 	flShowVersion := flag.Bool("version", false, "Show version information")
+	flKeepCache := flag.Bool("keep-cache", false, "Keep the cache between restarts")
 	flag.Parse()
 
 	if *flShowVersion {
@@ -283,8 +284,10 @@ func main() {
 	GSettings.CacheDir = path.Join(GSettings.CacheDir, "pkgproxy")
 	GSettings.UpstreamServer = *flUpstream
 
-	setupCacheDir()
-	defer destroyCacheDir()
+	if !*flKeepCache {
+		setupCacheDir()
+		defer destroyCacheDir()
+	}
 
 	http.HandleFunc("/", handler)
 	log.Fatal(http.ListenAndServe(*flAddr, nil))


### PR DESCRIPTION
It may be useful to keep the downloaded packages between pkgproxy restarts (i.e. using it to serve packages to a large number of local systems, but the machine must be restarted).

Database files are always re-downloaded after a restart, due to the fact that the CacheMap is initially empty.

The default behavior (when the new option is not used) is the clear the cache, as before.